### PR TITLE
Prototype for tracking draft history

### DIFF
--- a/app/mtga_app.py
+++ b/app/mtga_app.py
@@ -56,7 +56,7 @@ class MTGAWatchApplication(object):
         self.player_id = None
         self.intend_to_join_game_with = None
         self.player_decks = {}
-        self.draft_history = []
+        self.draft_history = {}
         self.last_blob = None
         self.error_count = 0
         self.collection = {}

--- a/app/mtga_app.py
+++ b/app/mtga_app.py
@@ -56,6 +56,7 @@ class MTGAWatchApplication(object):
         self.player_id = None
         self.intend_to_join_game_with = None
         self.player_decks = {}
+        self.draft_history = []
         self.last_blob = None
         self.error_count = 0
         self.collection = {}

--- a/app/parsers.py
+++ b/app/parsers.py
@@ -48,19 +48,44 @@ def parse_draft_status(blob):
             (a.RarityRank() == b.RarityRank() && a.ColorRank() == b.ColorRank() && a.CMC < b.CMC) ||
             (a.RarityRank() == b.RarityRank() && a.ColorRank() == b.ColorRank() && a.CMC == b.CMC && a.Name < b.Name)"""
     import app.mtga_app as mtga_app
+
     collection_count = []
     picked_cards_this_draft = []
     if "pickedCards" in blob and blob["pickedCards"]:
         picked_cards_this_draft = blob["pickedCards"]
-    for card in blob["draftPack"]:
-        card_obj = util.all_mtga_cards.find_one(card).to_serializable()
-        if card in mtga_app.mtga_watch_app.collection:
-            card_obj["count"] = min(mtga_app.mtga_watch_app.collection[card] + picked_cards_this_draft.count(card), 4)
-        else:
-            card_obj["count"] = min(0 + picked_cards_this_draft.count(card), 4)
-        collection_count.append(card_obj)
-    collection_count.sort(key=lambda x: (-1 * util.rank_rarity(x["rarity"]), util.rank_colors(x["color_identity"]), util.rank_cost(x["cost"]), x["pretty_name"]))
-    general_output_queue.put({"draft_collection_count": collection_count})
+
+    if blob["draftPack"]:
+        for card in blob["draftPack"]:
+            card_obj = util.all_mtga_cards.find_one(card).to_serializable()
+            if card in mtga_app.mtga_watch_app.collection:
+                card_obj["count"] = min(mtga_app.mtga_watch_app.collection[card] + picked_cards_this_draft.count(card), 4)
+            else:
+                card_obj["count"] = min(0 + picked_cards_this_draft.count(card), 4)
+            collection_count.append(card_obj)
+        collection_count.sort(key=lambda x: (-1 * util.rank_rarity(x["rarity"]), util.rank_colors(x["color_identity"]), util.rank_cost(x["cost"]), x["pretty_name"]))
+        general_output_queue.put({"draft_collection_count": collection_count})
+
+        draft_history_event = {"picks": picked_cards_this_draft, "pack": blob['draftPack']}
+        mtga_app.mtga_watch_app.draft_history.append(draft_history_event)
+        #app.mtga_app.mtga_logger.debug("{}%s".format(util.ld())%mtga_app.mtga_watch_app.draft_history )
+    else:
+        draft_history_event = {"picks": picked_cards_this_draft, "pack": []}
+        mtga_app.mtga_watch_app.draft_history.append(draft_history_event)
+
+        compressed_history = []
+        i = 0
+        while i < len(mtga_app.mtga_watch_app.draft_history)-1:
+            old = mtga_app.mtga_watch_app.draft_history[i]['picks'][:]
+            new = mtga_app.mtga_watch_app.draft_history[i+1]['picks'][:]
+            for c in old:
+                new.remove(c)
+            compressed_history.append({'pack': mtga_app.mtga_watch_app.draft_history[i]['pack'], 'pick': new[0]})
+            i += 1
+
+        # send compressed_history to inspector or output to a file or something
+        app.mtga_app.mtga_logger.debug("{}%s".format(util.ld())%"DRAFT COMPLETE!!!!" )
+        app.mtga_app.mtga_logger.debug("{}%s".format(util.ld())%compressed_history )
+        mtga_app.mtga_watch_app.draft_history = []
 
 
 @util.debug_log_trace


### PR DESCRIPTION
Prototype implementation of the draft-tracking feature request. #274 

During the draft, the state of the pick and pack zones at each step are stored. After the last card is chosen, the entire history is parsed and put into a compressed form in order to be sent to the inspector or whatever. Right now I just dump it into the logger, since I figure you might want to think over how you want to push to the inspector.

I wrote up an example of this format in a gist pulling from one of my test drafts: https://gist.github.com/isharacomix/86ad7c3308c698cd2986dc2ae30e2f00

During testing, I discovered that when the last card is chosen, `blob["draftPack"]` is actually `None`, which causes an exception to be thrown in the current code.

Feel free to use, ignore, or take apart for spare pieces. Roughly 3000 gems went into testing this. 💎 