### PR TITLE
#282 - Add CSS to trim deck names after 15 characters to prevent butt…

### DIFF
--- a/electron/minimal.css
+++ b/electron/minimal.css
@@ -110,11 +110,17 @@ h1 {
   left: 20px;
   position: relative;
   padding-top: 0px;
-  max-width: 245px;
+  max-width: 15ch;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .game-deck-title {
-  max-width: 245px;
+  max-width: 15ch;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
   display: inline-block;
 }
 


### PR DESCRIPTION
Add CSS to trim deck names after 15 characters to prevent buttons from being covered.

I wasn't sure if I should do this programmatically when assigning deck names or in CSS. I chose CSS since it seems less heavy handed and not much to change needed.

15 Characters seemed like a good limit to prevent overflow on the buttons.

