### PR TITLE
Issue #66: Add click to drag anywhere

### DIFF
--- a/electron/style.css
+++ b/electron/style.css
@@ -32,6 +32,10 @@ html {
     -webkit-user-select: none;
 }
 
+body {
+    -webkit-app-region: drag
+}
+
 .inline-block {
     display: inline-block;
 }
@@ -453,4 +457,14 @@ p {
 
 #opponent-timer {
     float: right;
+}
+
+/* The following classes should be set to no-drag or they won't be clickable */
+.zoom,
+.dismiss-message,
+.update-message,
+.settings-img,
+.back-link:after,
+.deck-container {
+	-webkit-app-region: no-drag;
 }

--- a/electron/style.css
+++ b/electron/style.css
@@ -33,7 +33,7 @@ html {
 }
 
 body {
-    -webkit-app-region: drag
+    -webkit-app-region: drag;
 }
 
 .inline-block {


### PR DESCRIPTION
Add the ability to drag the application from almost anywhere on the application body. The exception is elements where an action is taken on a click (e.g. settings gear icon, zoom -/+, etc...), as the event won't fire if dragging is enabled for that element.