### PR TITLE
run from source requires electon/legal

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Note that if you choose to skip Git Bash, you're on your own w.r.t. formatting s
     ```
 1. If all went well, you should now be able to:
     ```bash
-    ./node_modules/.bin/electron .
+    npm start
     ```
     And the decktracker UI should launch!
     

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1767,12 +1767,50 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
+    "ncp": {
+      "version": "0.4.2",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
+      "dev": true
+    },
     "node-abi": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
       "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
       "requires": {
         "semver": "^5.4.1"
+      }
+    },
+    "node-fs-extra": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/node-fs-extra/-/node-fs-extra-0.8.2.tgz",
+      "integrity": "sha1-CfsrYNMPfXA+Nh7LYmqRQE8XCXo=",
+      "dev": true,
+      "requires": {
+        "jsonfile": "~1.1.0",
+        "mkdirp": "0.3.x",
+        "ncp": "~0.4.2",
+        "rimraf": "~2.2.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
+          "integrity": "sha1-2k/WrXfxolUgPqY8e8Mtwx72RDM=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        }
       }
     },
     "node-gyp": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -4,7 +4,8 @@
     "description": "Application to track MTGA decks in-game",
     "main": "main.js",
     "scripts": {
-        "prestart": "xcopy \"..\\legal\" \".\\legal\" /i /y",
+        "copylegal": "node ./scripts/copy-legal.js",
+        "prestart": "npm run copylegal",
         "start": "electron .",
         "postinstall": "./node_modules/.bin/electron-rebuild -m . -w keytar,active-win -p -f"
     },
@@ -42,7 +43,8 @@
     },
     "devDependencies": {
         "electron-packager": "^9.1.0",
-        "grunt-electron-installer": "^2.1.0"
+        "grunt-electron-installer": "^2.1.0",
+        "node-fs-extra": "^0.8.2"
     },
     "//": [
         "cryptiles not a requirement, but locked due to https://nvd.nist.gov/vuln/detail/CVE-2018-1000620"

--- a/electron/package.json
+++ b/electron/package.json
@@ -4,6 +4,7 @@
     "description": "Application to track MTGA decks in-game",
     "main": "main.js",
     "scripts": {
+        "prestart": "xcopy \"..\\legal\" \".\\legal\" /i /y",
         "start": "electron .",
         "postinstall": "./node_modules/.bin/electron-rebuild -m . -w keytar,active-win -p -f"
     },

--- a/electron/scripts/copy-legal.js
+++ b/electron/scripts/copy-legal.js
@@ -1,0 +1,3 @@
+const fs = require('fs-extra');
+
+fs.copySync('../legal', './legal');


### PR DESCRIPTION
related to https://github.com/mtgatracker/mtgatracker/issues/253 and https://github.com/mtgatracker/mtgatracker/commit/d2c4deb02b902fe9a87a1340245ef9e41488aaf6

electron fails to start because `electron/legal/` is missing from repo. 
PR to put back `.gitignore` line https://github.com/mattbreckon/mtgatracker/pull/1 after.