### PR TITLE
Wins by deck

### DIFF
--- a/app/models/game.py
+++ b/app/models/game.py
@@ -154,7 +154,6 @@ class Player(object):
             "stats": list(reversed(odds_list)),
             "original_deck_stats": list(reversed(original_odds_list)),
             "deck_name": self.original_deck.pool_name,
-            #"deck_id": self.original_deck.deckID,
             "total_cards_in_deck": len(current_list),
             "original_decklist_total": len(self.original_deck.cards),
             "library_contents": [c.to_serializable() for c in current_list],

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -154,6 +154,7 @@ class Player(object):
             "stats": list(reversed(odds_list)),
             "original_deck_stats": list(reversed(original_odds_list)),
             "deck_name": self.original_deck.pool_name,
+            #"deck_id": self.original_deck.deckID,
             "total_cards_in_deck": len(current_list),
             "original_decklist_total": len(self.original_deck.cards),
             "library_contents": [c.to_serializable() for c in current_list],
@@ -252,6 +253,7 @@ class Game(object):
         hero_chess_time_total, oppo_chess_time_total = self.calculate_chess_timer_total()
         game_state = {
             "game_id": self.match_id,
+            "deck_id": self.hero.original_deck.deck_id,
             "draw_odds": self.hero.calculate_draw_odds(self.ignored_iids),
             "opponent_hand": [c.to_serializable() for c in self.opponent.hand.cards],
             "elapsed_time": str(datetime.datetime.now() - self.start_time),

--- a/electron/main.js
+++ b/electron/main.js
@@ -232,6 +232,11 @@ if (frameCmdOpt) {
   settings.set('useFrame', true)
 }
 
+// Hack to update to new structure
+if (settings.has('winLossCounter.win') && settings.has('winLossCounter.loss')) {
+  settings.set('winLossCounter.total', settings.get('winLossCounter'))
+}
+
 let debug = settings.get('debug', false);
 let mtgaOverlayOnly = settings.get('mtgaOverlayOnly', true);
 let showErrors = settings.get('showErrors', false);
@@ -250,7 +255,7 @@ let showChessTimers = settings.get('showChessTimers', true);
 let hideDelay = settings.get('hideDelay', 10);
 let invertHideMode = settings.get('invertHideMode', false);
 let rollupMode = settings.get('rollupMode', true);
-let winLossCounter = settings.get('winLossCounter', {win: 0, loss: 0});
+let winLossCounter = settings.get('winLossCounter', {total: {win: 0, loss: 0}});
 let showWinLossCounter = settings.get('showWinLossCounter', true);
 let showVaultProgress = settings.get('showVaultProgress', true);
 let lastCollection = settings.get('lastCollection', {});

--- a/electron/main.js
+++ b/electron/main.js
@@ -234,7 +234,9 @@ if (frameCmdOpt) {
 
 // Hack to update to new structure
 if (settings.has('winLossCounter.win') && settings.has('winLossCounter.loss')) {
-  settings.set('winLossCounter.total', settings.get('winLossCounter'))
+  settings.set('winLossCounter.total', settings.get('winLossCounter'));
+  settings.delete('winLossCounter.win');
+  settings.delete('winLossCounter.loss');
 }
 
 let debug = settings.get('debug', false);

--- a/electron/main.js
+++ b/electron/main.js
@@ -233,10 +233,8 @@ if (frameCmdOpt) {
 }
 
 // Hack to update to new structure
-if (settings.has('winLossCounter.win') && settings.has('winLossCounter.loss')) {
+if (!settings.has('winLossCounter.total') && settings.has('winLossCounter.win') && settings.has('winLossCounter.loss')) {
   settings.set('winLossCounter.total', settings.get('winLossCounter'));
-  settings.delete('winLossCounter.win');
-  settings.delete('winLossCounter.loss');
 }
 
 let debug = settings.get('debug', false);


### PR DESCRIPTION
Added tracking wins/losses in app on a per-deck basis. Structure change for WinLossCounter in settings:
Old:
winLossCounter: {win: %d, loss: %d}
New:
winLossCounter: {total: {win: %d, loss: %d}, %deck id%: {win: %d, loss: %d}, ...}

Swaps which set of win/loss statistics are used upon populating a deck into view (change to that deck - does not check that this deck exists and displays 0/0 if there is no data), unpopulating a deck (back to total wins/losses), and entering a game (change to that deck's statistics, if it is a saved deck). Statistics are only tracked for decklists which are saved in player decks - this could create problems down the line with deleting decks, but I can't see an elegant way to solve that while not generating vast amounts of waste from draft or other events which provide a nonstandard deck. Statistics are only saved when they change, not when they are viewed (so opening a deck to see 0 wins, 0 losses does not get saved, but winning a game with it will be)

Currently missing pruning on these statistics - when decks are deleted, should check to see if there are saved win/loss values for these, and if so remove them.

To support the changes to display, have also edited the python to have game_state always report the deck ID (if known) and edited main.js to automatically migrate old style winLossCounter to new format (non destructively, though the old data will not be maintained).