### PR TITLE
added a setting to minimize the main window to the icon tray

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -10,7 +10,7 @@ if (handleStartupEvent()) {
   return;
 }
 
-const { app, ipcMain, BrowserWindow } = require('electron')
+const { app, ipcMain, BrowserWindow, Tray, Menu } = require('electron')
 const fs = require('fs');
 const path = require('path')
 const keytar = require('keytar')
@@ -262,6 +262,7 @@ let useMinimal = settings.get('useMinimal', true);
 let zoom = settings.get('zoom', 0.8);
 let recentCards = settings.get('recentCards', []);
 let recentCardsQuantityToShow = settings.get('recentCardsQuantityToShow', 10);
+let minToTray = settings.get('minToTray', false);
 logPath = settings.get("logPath", logPath)
 
 global.historyEvents = []
@@ -612,6 +613,7 @@ global.zoom = zoom
 global.recentCards = recentCards
 global.recentCardsQuantityToShow = recentCardsQuantityToShow
 global.logPath = logPath
+global.minToTray = minToTray
 global.historyZoom = settings.get("history-zoom", 1.0)
 
 /*************************************************************
@@ -630,6 +632,38 @@ if (debug) {
     window_height = 700;
 }
 
+const openDeckTrackerHandler = (menuItem, browserWindow, event) => {
+    focusMTGATracker(); 
+}
+
+const openSettingsHandler = (menuItem, browserWindow, event) => {
+  focusMTGATrackerSettings();
+}
+
+const openHistoryHandler = (menuItem, browserWindow, event) => {
+  focusMTGAHistory();
+}
+
+const closeTrackerHandler = (menuItem, browserWindow, event) => {
+  mainWindow.close();
+}
+
+let tray = null;
+
+const createTray = () => {
+  if(minToTray && tray==null) {
+    tray = new Tray('img/icon_small.ico')
+    const contextMenu = Menu.buildFromTemplate([
+      {label: "DeckTracker", type: "normal", click: openDeckTrackerHandler},
+      {label: "Settings", type: "normal", click: openSettingsHandler},
+      {label: "History", type: "normal", click: openHistoryHandler},
+      {label: "Quit", type: "normal", click: closeTrackerHandler }
+    ])
+    tray.setToolTip('MTGA Tracker')
+    tray.setContextMenu(contextMenu)
+  }
+}
+
 const createMainWindow = () => {
   const mainWindowStateMgr = windowStateKeeper('main')
   mainWindow = new BrowserWindow({width: window_width,
@@ -646,6 +680,7 @@ const createMainWindow = () => {
                                   icon: "img/icon_small.ico",
                                   x: mainWindowStateMgr.x,
                                   y: mainWindowStateMgr.y})
+  createTray();
   mainWindowStateMgr.track(mainWindow)
   mainWindow.loadURL(require('url').format({
     pathname: path.join(__dirname, 'index.html'),
@@ -655,6 +690,11 @@ const createMainWindow = () => {
   mainWindow.on('closed', () => {
     console.log("main window closed")
     killServer()
+  })
+  mainWindow.on('minimize', () => {
+    minToTray = settings.get('minToTray', false);
+    createTray();
+    mainWindow.setSkipTaskbar(minToTray)
   })
 
   if (debug) {
@@ -688,10 +728,38 @@ const openFirstWindow = () => {
 
 function focusMTGATracker() {
   if(mainWindow) {
+    mainWindow.setSkipTaskbar(false);
+    mainWindow.show();
     if(mainWindow.isMinimized()) {
       mainWindow.restore();
     }
     mainWindow.focus();
+  } else {
+    openFirstWindow();
+  }
+}
+
+function focusMTGATrackerSettings() {
+  if(settingsWindow) {
+    settingsWindow.show();
+    if(settingsWindow.isMinimized()) {
+      settingsWindow.restore();
+    }
+    settingsWindow.focus();
+  } else {
+    openSettingsWindow();
+  }
+}
+
+function focusMTGAHistory() {
+  if(historyWindow) {
+    historyWindow.show();
+    if(historyWindow.isMinimized()) {
+      historyWindow.restore();
+    }
+    historyWindow.focus();
+  } else {
+    openHistoryWindow();
   }
 }
 

--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -66,6 +66,7 @@ var showChessTimers = remote.getGlobal('showChessTimers');
 var hideDelay = remote.getGlobal('hideDelay');
 var invertHideMode = remote.getGlobal('invertHideMode');
 var rollupMode = remote.getGlobal('rollupMode');
+var minToTray = remote.getGlobal('minToTray');
 var recentCardsQuantityToShow = remote.getGlobal('recentCardsQuantityToShow');
 var showGameTimer = remote.getGlobal('showGameTimer');
 var zoom = remote.getGlobal('zoom');
@@ -171,6 +172,7 @@ var appData = {
     rollupMode: rollupMode,
     recentCardsQuantityToShow: recentCardsQuantityToShow,
     recentCards: recentCards,
+    minToTray: minToTray,
 }
 
 var parseVersionString = (versionStr) => {
@@ -1124,6 +1126,9 @@ ipcRenderer.on('settingsChanged', () => {
 
   recentCards = remote.getGlobal('recentCards');
   appData.recentCards = recentCards
+
+  minToTray = remote.getGlobal('minToTray');
+  appData.minToTray = minToTray
 
   winLossCounter = remote.getGlobal('winLossCounter');
   appData.winCounter = winLossCounter.win

--- a/electron/settings.html
+++ b/electron/settings.html
@@ -384,6 +384,9 @@
           <div class="settings-row">
             <input rv-checked="mtgaOverlayOnly" class="tf-toggle" type="checkbox" key="mtgaOverlayOnly" data-toggle="toggle"> Overlay on MTGA <i>only</i> ("Off" means overlay <i>always</i>)
           </div>
+          <div class="settings-row">
+            <input rv-checked="minToTray" class="tf-toggle" type="checkbox" key="minToTray" data-toggle="toggle"> Minimize to tray
+          </div>
 
           <hr />
           <div class="settings-row">

--- a/electron/settingsRenderer.js
+++ b/electron/settingsRenderer.js
@@ -49,6 +49,7 @@ var settingsData = {
   rollupMode: remote.getGlobal('rollupMode'),
   recentCards: remote.getGlobal('recentCards'),
   recentCardsQuantityToShow: remote.getGlobal('recentCardsQuantityToShow'),
+  minToTray: remote.getGlobal('minToTray'),
   runFromSource: remote.getGlobal('runFromSource'),
   sortMethodSelected: remote.getGlobal('sortMethod'),
   useFlat: remote.getGlobal('useFlat'),


### PR DESCRIPTION
resolves #207 

I added a new setting to minimize the main window to the icon tray.

It only operates on the main window as I figured the other windows are kinda auxiliary and the user wouldn't normally minimize them and instead close them unless they needed to use the settings/history immediately. 

If the setting is switched off, the tracker does need to be restarted if the user wants the icon to disappear from the tray. This could probably be fixed by listening in on the settings changes but I'm not entirely sure it's necessary since the icon's usually end up in the hidden icons tray anyways. 

Also, on my machine multiple icons spawn when the app starts with the new setting on but quickly disappear. I'm not sure if it happens elsewhere as I can't see why it'd happen in the code. Wouldn't mind if someone could verify if that happens on their end!

Demo:
[https://youtu.be/C8ZOB6mJQ5I](https://youtu.be/C8ZOB6mJQ5I)