### PR TITLE
added twitch precon to the map

### DIFF
--- a/util.py
+++ b/util.py
@@ -114,6 +114,8 @@ PRECON_MAP = {
     "?=?Loc/Decks/Precon/Precon_NPE_GRN_UG": "Jungle Secrets",
     "?=?Loc/Decks/Precon/Precon_NPE_GRN_RW": "Strength in Numbers",
     "?=?Loc/Decks/Precon/Precon_NPE_GRN_WU": "Artifacts Attack",
+    # twitch precon
+    "?=?Loc/Decks/Precon/Precon_TwitchCon2018": "Selesnya Conclave",
 }
 
 


### PR DESCRIPTION
So I won one of these from Gaby's stream which is why I was able to see the name in the log file :p
 
Discord user Pteryon on 10/23/2018 reported that this is also an issue with planeswalker decks you can buy irl. 