### PR TITLE
Remove old win counter update

### DIFF
--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -1238,10 +1238,6 @@ ipcRenderer.on('settingsChanged', () => {
   minToTray = remote.getGlobal('minToTray');
   appData.minToTray = minToTray
 
-  winLossCounter = remote.getGlobal('winLossCounter');
-  appData.winCounter = winLossCounter.win
-  appData.lossCounter = winLossCounter.loss
-
   let useTheme = remote.getGlobal("useTheme")
   let themeFile = remote.getGlobal("themeFile")
   let useFlat = remote.getGlobal("useFlat")


### PR DESCRIPTION
References to the old win counter crept back in with the other merges. Shouldn't hurt to have them, but removing them is best.