### PR TITLE
Update decklist sorting

### DIFF
--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -292,7 +292,7 @@ let drawSort = function (decklist,by_name) {
   let sorted = [];
   for (sublist of sublists){
     if (by_name) {
-      sorted.push(sublist.sort( function (a,b) { return nameCompare(a.pretty_name,b.pretty_name); } ));
+      sorted.push(sublist.sort( (a,b) => { return nameCompare(a.pretty_name,b.pretty_name); } ));
     } else {
       sorted.push(emeraldSort(sublist));
     }

--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -256,6 +256,53 @@ request.get({
   }
 })
 
+let emeraldSort = function (decklist) {
+   return decklist.sort(
+            function (a, b) {
+                // Sort by cardtype first
+                return cardtypeCompare(a.card_type, b.card_type)
+                        // Then sort by mana cost
+                        || manaCostCompare(a.cost, b.cost)
+                        // Then sort by name
+                        || nameCompare(a.pretty_name, b.pretty_name);
+            }
+    );
+};
+
+let deckSubLists = function (decklist) {
+  let card_count = -1;
+  let sublists = [];
+  let current_sublist = null;
+  for ( card of decklist ) {
+    if (card.count_in_deck != card_count){
+      if ( current_sublist != null ){
+        sublists.push(current_sublist);
+        current_sublist = [];
+      } else {
+        current_sublist = [];
+      }
+      card_count = card.count_in_deck;
+    }
+    current_sublist.push(card);
+  }
+  sublists.push(current_sublist);
+  return sublists;
+};
+
+let drawSort = function (decklist,by_name) {
+  let sublists = deckSubLists(decklist);
+  let sorted = [];
+  for (sublist of sublists){
+    if (by_name) {
+      sorted.push(sublist.sort( function (a,b) { return nameCompare(a.pretty_name,b.pretty_name); } ));
+    } else {
+      sorted.push(emeraldSort(sublist));
+    }
+  }
+  //flatten
+  return [].concat.apply([], sorted);
+}
+
 let cardtypeCompare = function (a, b) {
     // Creatures -> Planeswalkers -> Enchantments -> Artifacts -> Sorceries -> Instants -> Non-Basic Lands -> Basic Lands
     if (a.includes("Creature")) {
@@ -369,18 +416,10 @@ rivets.formatters.drawStatsSort = function(decklist) {
     if (decklist.length === 0) {
         return decklist;
     }
-    if (sortMethod == "draw") {
-        return decklist;
+    if (sortMethod.startsWith("draw")) {
+        return drawSort(decklist,sortMethod === 'draw');
     } else if (sortMethod == "emerald") {
-        return decklist.sort(
-                function (a, b) {
-                    // Sort by cardtype first
-                    return cardtypeCompare(a.card_type, b.card_type)
-                        // Then sort by mana cost
-                        || manaCostCompare(a.cost, b.cost)
-                        // Then sort by name
-                        || nameCompare(a.card, b.card);
-                });
+        return emeraldSort(decklist);
     }
 };
 
@@ -401,18 +440,10 @@ rivets.formatters.decklistSort = function(decklist) {
     if (decklist.length === 0) {
         return decklist;
     }
-    if (sortMethod == "draw") {
-        return decklist;
+    if (sortMethod.startsWith("draw")) {
+        return drawSort(decklist,sortMethod === 'draw');
     } else if (sortMethod == "emerald") {
-        return decklist.sort(
-            function (a, b) {
-                // Sort by cardtype first
-                return cardtypeCompare(a.card_type, b.card_type)
-                        // Then sort by mana cost
-                        || manaCostCompare(a.cost, b.cost)
-                        // Then sort by name
-                        || nameCompare(a.pretty_name, b.pretty_name);
-        });
+        return emeraldSort(decklist);
     }
 };
 

--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -277,10 +277,8 @@ let deckSubLists = function (decklist) {
     if (card.count_in_deck != card_count){
       if ( current_sublist != null ){
         sublists.push(current_sublist);
-        current_sublist = [];
-      } else {
-        current_sublist = [];
       }
+      current_sublist = [];
       card_count = card.count_in_deck;
     }
     current_sublist.push(card);

--- a/electron/settingsRenderer.js
+++ b/electron/settingsRenderer.js
@@ -70,11 +70,11 @@ var settingsData = {
   customStyleFiles: [],
   sortingMethods: [
     {id: "draw", text: "By likelihood of next draw, then by name (default)",
-    help: "This method shows cards in order from most likely to draw on top of the list to least likely to draw on the bottom, followed by name within a given frequency."},
+    help: "This method shows cards in order from most likely to draw on top of the list to least likely to draw on the bottom, followed by name within a given likelihood."},
     {id: "emerald", text: '"Emerald" method',
     help: "This method sorts cards by card type, then by cost, then by name."},
     {id: "draw-emerald", text: 'By likelihood of next draw, then by the "Emerald" method',
-    help: "This method sorts cards by likelihood of next draw, then, within a frequency, by card type, then by cost, then by name."}
+    help: "This method sorts cards by likelihood of next draw, then, within a likelihood, by card type, then by cost, then by name."}
   ],
 }
 

--- a/electron/settingsRenderer.js
+++ b/electron/settingsRenderer.js
@@ -69,10 +69,12 @@ var settingsData = {
   trackerID: remote.getGlobal('trackerID'),
   customStyleFiles: [],
   sortingMethods: [
-    {id: "draw", text: "By likelihood of next draw (default)",
-    help: "This method shows cards in order from most likely to draw on top of the list to least likely to draw on the bottom, with no other considerations."},
+    {id: "draw", text: "By likelihood of next draw, then by name (default)",
+    help: "This method shows cards in order from most likely to draw on top of the list to least likely to draw on the bottom, followed by name within a given frequency."},
     {id: "emerald", text: '"Emerald" method',
-    help: "This method sorts cards by card type, then by cost, then by name."}
+    help: "This method sorts cards by card type, then by cost, then by name."},
+    {id: "draw-emerald", text: 'By likelihood of next draw, then by the "Emerald" method',
+    help: "This method sorts cards by likelihood of next draw, then, within a frequency, by card type, then by cost, then by name."}
   ],
 }
 

--- a/electron/settingsRenderer.js
+++ b/electron/settingsRenderer.js
@@ -73,8 +73,12 @@ var settingsData = {
     help: "This method shows cards in order from most likely to draw on top of the list to least likely to draw on the bottom, followed by name within a given likelihood."},
     {id: "emerald", text: '"Emerald" method',
     help: "This method sorts cards by card type, then by cost, then by name."},
+    {id: "color", text: 'Sorts first by cost, then color, then name.',
+    help: "This method sorts cards first by cost, then color, then by name."},
     {id: "draw-emerald", text: 'By likelihood of next draw, then by the "Emerald" method',
-    help: "This method sorts cards by likelihood of next draw, then, within a likelihood, by card type, then by cost, then by name."}
+    help: "This method sorts cards by likelihood of next draw, then, within a likelihood, by card type, then by cost, then by name."},
+    {id: "draw-color", text: 'By likelihood of next draw, then by cost, color, and name',
+    help: "This method sorts cards by likelihood of next draw, then, by cost, then color, then by name."},
   ],
 }
 


### PR DESCRIPTION
Implement subsorting for draw (likelihood) sort. 

Given this list of cards remaining:
```
2x Essence Scatter
4x Tempest Djinn
4x Opt
2x Nightveil Sprite
4x Merfolk Trickster
4x Curious Obsession
2x Warkite Marauder
```

This is a possible (unpredictable?) result of the current 'draw' (default) sort:
```
4x Tempest Djinn
4x Merfolk Trickster
4x Curious Obsession
4x Opt
2x Warkite Marauder
2x Essence Scatter
2x Nightveil Sprite
```

New default sort ('draw') now sorts by draw then by name within draw, i.e. you'll now see:
```
4x Curious Obsession
4x Merfolk Trickster
4x Opt
4x Tempest Djinn
2x Essence Scatter
2x Nightveil Sprite
2x Warkite Marauder
```

Also added Emerald subsort, so given the above, you'd see:
```
4x Merfolk Trickster
4x Tempest Djinn
4x Curious Obsession
4x Opt
2x Nightveil Sprite
2x Warkite Marauder
2x Essence Scatter
```

