### PR TITLE
Fix deck counter display on deck populate

### DIFF
--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -625,9 +625,9 @@ function populateDeck(elem) {
       if (appData.winLossObj[type][deckID] === undefined) {
         appData.winLossObj[type][deckID] = {win: 0, loss: 0, name: deck.pool_name}
       }
-      const counter_prefix = type === 'daily' ? 'dailyD' : 'd';
-      appData[counter_prefix + 'eckWinCounter'] = appData.winLossObj[type][deckID].win;
-      appData[counter_prefix + 'eckLossCounter'] = appData.winLossObj[type][deckID].loss;
+      const counter_prefix = type === 'daily' ? 'dailyDeck' : 'deck';
+      appData[counter_prefix + 'WinCounter'] = appData.winLossObj[type][deckID].win;
+      appData[counter_prefix + 'LossCounter'] = appData.winLossObj[type][deckID].loss;
     });
 
     if (deck != null){

--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -625,9 +625,9 @@ function populateDeck(elem) {
       if (appData.winLossObj[type][deckID] === undefined) {
         appData.winLossObj[type][deckID] = {win: 0, loss: 0, name: deck.pool_name}
       }
-      const counter_name = type === 'daily' ? 'dailyDeckWinCounter' : 'deckWinCounter';
-      appData[counter_name] = appData.winLossObj[type][deckID].win;
-      appData[counter_name] = appData.winLossObj[type][deckID].loss;
+      const counter_prefix = type === 'daily' ? 'dailyD' : 'd';
+      appData[counter_prefix + 'eckWinCounter'] = appData.winLossObj[type][deckID].win;
+      appData[counter_name + 'eckLossCounter'] = appData.winLossObj[type][deckID].loss;
     });
 
     if (deck != null){

--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -627,7 +627,7 @@ function populateDeck(elem) {
       }
       const counter_prefix = type === 'daily' ? 'dailyD' : 'd';
       appData[counter_prefix + 'eckWinCounter'] = appData.winLossObj[type][deckID].win;
-      appData[counter_name + 'eckLossCounter'] = appData.winLossObj[type][deckID].loss;
+      appData[counter_prefix + 'eckLossCounter'] = appData.winLossObj[type][deckID].loss;
     });
 
     if (deck != null){


### PR DESCRIPTION
Heh! You talked me into a bug! I was using the prefix and 'golfing' because I needed to reference:
```
dailyDeckWinCounter
deckWinCounter
dailyDeckLossCounter
deckLossCounter
```
Thus the use of the prefix, so I can say just `prefix + type`.

This should be fixed before release.