### PR TITLE
Potential fix for resizeWindow() that seems to affect a very small percent of users

### DIFF
--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -706,6 +706,9 @@ ws.addEventListener('open', () => {
     console.log("sent hello")
 });
 
+var boundsRoundingErrorX = false;
+var boundsRoundingErrorY = false;
+
 function resizeWindow() {
     let total = 0;
     $.each($(".card"), function(i, c) {
@@ -724,6 +727,9 @@ function resizeWindow() {
     });
 
     bounds = browserWindow.getBounds()
+    var preboundsx = browserWindow.getBounds().x;
+    var preboundsy = browserWindow.getBounds().y;
+
     container.style.height = "" + parseInt(totalHeight) + "px"
     if (zoom > 0.85) {
       // TODO: resize with math that is less "throwing shit at the wall"
@@ -744,7 +750,19 @@ function resizeWindow() {
     }
     bounds.height = Math.min(parseInt(totalHeight), calcMainMaxHeight());
     if (!(debug || useFrame)) {
-        browserWindow.setBounds(bounds)
+      if(boundsRoundingErrorX) {
+        bounds.x = preboundsx + 1;
+      }
+      if(boundsRoundingErrorY) {
+        bounds.y = preboundsy + 1;
+      }
+      browserWindow.setBounds(bounds)
+      if(preboundsx!=browserWindow.getBounds().x) {
+        boundsRoundingErrorX = true;
+      }
+      if(preboundsy!=browserWindow.getBounds().y) {
+        boundsRoundingErrorY = true;
+      }
     }
 }
 

--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -706,10 +706,11 @@ ws.addEventListener('open', () => {
     console.log("sent hello")
 });
 
-var boundsRoundingErrorX = false;
-var boundsRoundingErrorY = false;
+let boundsRoundingErrorX = false;
+let boundsRoundingErrorY = false;
 
 function resizeWindow() {
+    checkForSetBoundsMovement();
     let total = 0;
     $.each($(".card"), function(i, c) {
         total += c.offsetHeight;
@@ -727,9 +728,8 @@ function resizeWindow() {
     });
 
     bounds = browserWindow.getBounds()
-    var preboundsx = browserWindow.getBounds().x;
-    var preboundsy = browserWindow.getBounds().y;
-
+    var prevBoundsX = bounds.x;
+    var prevBoundsY = bounds.y;
     container.style.height = "" + parseInt(totalHeight) + "px"
     if (zoom > 0.85) {
       // TODO: resize with math that is less "throwing shit at the wall"
@@ -751,19 +751,38 @@ function resizeWindow() {
     bounds.height = Math.min(parseInt(totalHeight), calcMainMaxHeight());
     if (!(debug || useFrame)) {
       if(boundsRoundingErrorX) {
-        bounds.x = preboundsx + 1;
+        bounds.x = prevBoundsX + 1;
       }
       if(boundsRoundingErrorY) {
-        bounds.y = preboundsy + 1;
+        bounds.y = prevBoundsY + 1;
       }
       browserWindow.setBounds(bounds)
-      if(preboundsx!=browserWindow.getBounds().x) {
-        boundsRoundingErrorX = true;
-      }
-      if(preboundsy!=browserWindow.getBounds().y) {
-        boundsRoundingErrorY = true;
-      }
     }
+}
+
+var firstRun = true;
+function checkForSetBoundsMovement() {
+  if(!firstRun) {
+    return;
+  }
+  if ((debug || useFrame)){
+    return;
+  }
+  var bounds = browserWindow.getBounds();
+  var prevBoundsX = bounds.x;
+  var prevBoundsY = bounds.y;
+  browserWindow.setBounds(bounds);
+  var newBounds = browserWindow.getBounds();
+  if(prevBoundsX!=newBounds.x) {
+    boundsRoundingErrorX = true;
+    newBounds.x+=2;
+  }
+  if(prevBoundsY!=newBounds.y) {
+    boundsRoundingErrorY = true;
+    newBounds.y+=2;
+  }
+  browserWindow.setBounds(newBounds);
+  firstRun = false;
 }
 
 function populateDeck(elem) {


### PR DESCRIPTION
resolves #421 

Upon the first call of resizeWindow(), the code now checks to see if setBounds() is doing what it's expected to do(ie leave bounds.x and bounds.y alone if it's been untouched). It might be better to check every call instead of just the first though.

I dunno what % of users this affects or if this is the proper way to handle it though. I'm not even sure it'll fix it for the other person who reported it. @shawkinsl what do you think about it? 