### PR TITLE
Adding Mousetrap and Ctrl+C event handlier to copy screen data.

### DIFF
--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -13,9 +13,21 @@ const { remote, ipcRenderer, shell, clipboard } = require('electron')
 const { Menu, MenuItem } = remote
 let browserWindow = remote.getCurrentWindow()
 const activeWin = require("active-win")
-
-
 const Mousetrap = require('Mousetrap')
+
+function contextData(data) {
+  // find out what context we are in.
+  // return data for that context as a single string value.
+  if (data.showDraftStats) {
+    return appData.draftStats.map(card=>card.pretty_name).join('\n')
+  } else if (data.list_selected) {
+    return dataString = data.selected_list.map(
+      c=>(c.count_in_deck + ' ' + c.pretty_name + ' (' + c.set + ') ' + c.set_number)
+    ).join('\n')
+  } else if (data.show_available_decklists) {
+    return dataString = data.player_decks.map( d=>d.pool_name ).join('\n')
+  }
+}
 
 function copyEventHandler(e) {
   // This should copy the data on the current screen onto the clipboard.
@@ -24,8 +36,9 @@ function copyEventHandler(e) {
   // TODO: deck lists.
 
   console.log('Copying relevant data to clipboard, if any.')
-  if (appData.showDraftStats) {
-    let dataString = appData.draftStats.map(card=>card.pretty_name).join('\n')
+  let dataString = contextData(appData)
+
+  if (dataString) {
     clipboard.writeText(dataString)
   }
 }

--- a/electron/mainRenderer.js
+++ b/electron/mainRenderer.js
@@ -9,10 +9,28 @@ const Timer = require('easytimer.js');
 const keytar = require('keytar')
 const hideWindowManager = require("./hide-manager")
 
-const { remote, ipcRenderer, shell } = require('electron')
+const { remote, ipcRenderer, shell, clipboard } = require('electron')
 const { Menu, MenuItem } = remote
 let browserWindow = remote.getCurrentWindow()
 const activeWin = require("active-win")
+
+
+const Mousetrap = require('Mousetrap')
+
+function copyEventHandler(e) {
+  // This should copy the data on the current screen onto the clipboard.
+  // The format should be context specific, comma or tab delimited seems 
+  // like the best choice for most stuff.
+  // TODO: deck lists.
+
+  console.log('Copying relevant data to clipboard, if any.')
+  if (appData.showDraftStats) {
+    let dataString = appData.draftStats.map(card=>card.pretty_name).join('\n')
+    clipboard.writeText(dataString)
+  }
+}
+Mousetrap.bind('ctrl+c', copyEventHandler)
+
 
 let addClickHandler = (selector,handler) => {
   let new_handler = (e) => {

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1770,6 +1770,11 @@
         }
       }
     },
+    "mousetrap": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.2.tgz",
+      "integrity": "sha512-jDjhi7wlHwdO6q6DS7YRmSHcuI+RVxadBkLt3KHrhd3C2b+w5pKefg3oj5beTcHZyVFA9Aksf+yEE1y5jxUjVA=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/electron/package.json
+++ b/electron/package.json
@@ -36,6 +36,7 @@
         "jsonwebtoken": "^8.3.0",
         "keytar": "^4.2.1",
         "markdown": "^0.5.0",
+        "mousetrap": "^1.6.2",
         "mtga": "^1.3.2",
         "npm": "^6.4.1",
         "reconnecting-websocket": "^3.2.2",


### PR DESCRIPTION
Adding the ability to easily copy the main data from screens.

Pressing Ctrl+C on either of the 3 screens will export a simple list of the main data on the current screen. list of cards, list of cards in magic arena format or list of deck names.

Closes #442