### PR TITLE
Add precon deck name map entry for "Wing and Claw"

### DIFF
--- a/util.py
+++ b/util.py
@@ -114,6 +114,8 @@ PRECON_MAP = {
     "?=?Loc/Decks/Precon/Precon_NPE_GRN_UG": "Jungle Secrets",
     "?=?Loc/Decks/Precon/Precon_NPE_GRN_RW": "Strength in Numbers",
     "?=?Loc/Decks/Precon/Precon_NPE_GRN_WU": "Artifacts Attack",
+    # guilds replacement precon
+    "?=?Loc/Decks/Precon/Precon_NPE_GRN_WU_2": "Wing and Claw",
     # twitch precon
     "?=?Loc/Decks/Precon/Precon_TwitchCon2018": "Selesnya Conclave",
 }


### PR DESCRIPTION
The GRN WU precon deck "Artifacts Attack" was replaced by "Wing and
Claw" for new players who joined the game later. Since this deck has a
new name, a new entry in the precon name map is required to de-uglify
the tracker for players who have this deck.

Closes #465