### PR TITLE
 Update default logfile name

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -200,7 +200,7 @@ let pyProc = null
 let pyPort = null
 
 let appDataRoaming = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + 'Library/Preferences' : '/var/local')
-let logPath = path.join(appDataRoaming, "..", "LocalLow", "Wizards Of The Coast", "MTGA", "output_log.txt");
+let logPath = path.join(appDataRoaming, "..", "LocalLow", "Wizards Of The Coast", "MTGA", "Player.txt");
 
 
 let getBooleanArg = (short, long) => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -200,7 +200,7 @@ let pyProc = null
 let pyPort = null
 
 let appDataRoaming = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + 'Library/Preferences' : '/var/local')
-let logPath = path.join(appDataRoaming, "..", "LocalLow", "Wizards Of The Coast", "MTGA", "Player.txt");
+let logPath = path.join(appDataRoaming, "..", "LocalLow", "Wizards Of The Coast", "MTGA", "Player.log");
 
 
 let getBooleanArg = (short, long) => {


### PR DESCRIPTION
The new MTGA game client has renamed `output_log.txt` to `Player.txt` - this PR updates the electron client to use the new file by default.

fixes #533 