### PR TITLE
Updated README.md to resolve mtgatracker/mtgatracker#561

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The use of MTGATracker is considered an implicit agreement to this policy.
 ### Credits, License
 
 MTGA Tracker is built with many free / oss libraries, in general listed in the various manifest files.
-MTGA Tracker is mainly built using [JetBrains' PyCharm](https://www.jetbrains.com/pycharm/), [cmder](http://cmder.net/),
+MTGA Tracker is mainly built using [JetBrains' PyCharm](https://www.jetbrains.com/pycharm/), [cmder](https://cmder.app/),
 [Electron](https://electronjs.org/), [Python](https://www.python.org/), and many other libraries and tools.
 
 Thanks to Auth0 for both the [webtask.io](https://webtask.io) serverless platform, which drives any web-based


### PR DESCRIPTION
Corrected the linked website for `cmder` from a scam link to the official website (see mtgatracker/mtgatracker#561)

The previous link (https://cmder.net/) looks (at time of commit) like a likely scam website about cashing 401K's into Gold

The corrected link (https://cmder.app/) is most likely the legitimate website, since (at time of commit) this instead is the website of a major GitHub project concerning a developer tool of the same name (https://github.com/cmderdev/cmder)